### PR TITLE
Fix blog pipeline: nav links, images, and container styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": false,
   "type": "module",
   "scripts": {
-    "dev": "bun scripts/build.ts generate && bun dist/index.html",
+    "dev": "bun scripts/build.ts generate && bunx serve dist",
     "build": "bun scripts/build.ts build",
     "sync": "bun scripts/sync-notes.ts",
     "deploy": "bun sync && bun build && bunx gh-pages -d dist"

--- a/pages/_default.html
+++ b/pages/_default.html
@@ -12,7 +12,7 @@
     <body>
         <div id="content">{{{ content }}}</div>
 
-        <footer class="footer">&copy; 2026, Siddharth Jha.</footer>
+        <footer class="footer container">&copy; 2026, Siddharth Jha.</footer>
 
         <script src="https://unpkg.com/lenis@1/dist/lenis.min.js"></script>
         <script type="module" src="./js/main.js"></script>

--- a/pages/_note.html
+++ b/pages/_note.html
@@ -21,7 +21,7 @@
             <div class="note-content">{{{ content }}}</div>
         </article>
 
-        <footer class="footer">&copy; 2026, Siddharth Jha.</footer>
+        <footer class="footer container">&copy; 2026, Siddharth Jha.</footer>
 
         <script src="https://unpkg.com/lenis@1/dist/lenis.min.js"></script>
         <script type="module" src="../../js/main.js"></script>

--- a/pages/_notes-listing.html
+++ b/pages/_notes-listing.html
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="../styles/main.css" />
     </head>
     <body>
-        <div class="notes-page">
+        <div class="notes-page container">
             <a class="back-link" href="../">← Home</a>
             <h1>Siddharth's</h1>
             <p class="subtitle script">notes, essays & musings</p>
@@ -20,7 +20,7 @@
             </ul>
         </div>
 
-        <footer class="footer">&copy; 2026, Siddharth Jha.</footer>
+        <footer class="footer container">&copy; 2026, Siddharth Jha.</footer>
 
         <script src="https://unpkg.com/lenis@1/dist/lenis.min.js"></script>
         <script type="module" src="../js/main.js"></script>

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,7 @@ title: Siddharth / @clearlysid
 description: Software Designer, Engineer and Generalist.
 ---
 
-<main class="home">
+<main class="home container">
 	<section class="home-hero">
 		<div class="home-head">
 			<h1>Siddharth</h1>
@@ -13,7 +13,7 @@ description: Software Designer, Engineer and Generalist.
 			<p>These days I build <a href="https://www.helmer.app">Helmer</a> — a bespoke video app, while helping a few friends with their own startups.</p>
 			<p>You'll often find me on long walks, reading memoirs, writing, cooking new recipes or befriending cats.</p>
 			<p>Welcome to my internet corner ~ ᕕ(ᐛ)ᕗ</p>
-			<a class="read-essays-btn" href="./notes/">Read Essays</a>
+			<a class="read-essays-btn" href="/notes/">Read Essays</a>
 			<p class="scroll-hint script">or scroll to explore my work ~</p>
 		</div>
 		<div class="hero-wrapper">

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -148,7 +148,7 @@ async function generateHTML() {
         /!\[\[([^\]]+)\]\]/g,
         (_, ref) => {
           const slugified = ref.replace(/\s+/g, "-").toLowerCase();
-          return `![](./attachments/${slugified})`;
+          return `![](../attachments/${slugified})`;
         },
       );
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -76,12 +76,14 @@ a {
     mask-image: linear-gradient(15deg, transparent 50%, black 100%);
 }
 
-/* ===== HOMEPAGE ===== */
-.home {
+/* ===== CONTAINER ===== */
+.container {
     max-width: calc(850px + 4rem);
     margin: 0 auto;
-    padding: 0 2rem 0;
+    padding: 0 2rem;
 }
+
+/* ===== HOMEPAGE ===== */
 
 .home-hero {
     display: flex;
@@ -405,9 +407,8 @@ a {
 
 /* Footer */
 .footer {
-    max-width: calc(850px + 4rem);
-    margin: 0 auto;
-    padding: 100px 2rem 24px;
+    padding-top: 100px;
+    padding-bottom: 24px;
     font-size: 14px;
     font-weight: 400;
     letter-spacing: -0.2px;
@@ -416,9 +417,6 @@ a {
 
 /* ===== NOTES LISTING PAGE ===== */
 .notes-page {
-    max-width: 850px;
-    margin: 0 auto;
-    padding: 0 2rem 0;
 }
 
 .back-link {


### PR DESCRIPTION
## Summary

Fixed multiple issues with the notes blog pipeline:
- Changed 'Read Essays' link from relative to absolute path to prevent URL nesting on repeated clicks
- Updated dev server to use static file serving instead of SPA mode
- Fixed Obsidian image embed paths to resolve correctly from nested note pages
- Extracted shared container styles to reduce duplication across pages

The kitchen sink test note now renders correctly with proper styling and image display.