### PR TITLE
Fix mobile responsiveness: noise and hero image layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -686,12 +686,48 @@ sup {
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 860px) {
+    #noise-overlay {
+        left: 0;
+        width: 100vw;
+        -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%);
+        mask-image: linear-gradient(to bottom, black 0%, transparent 100%);
+    }
+
     .home-hero {
+        position: relative;
         flex-direction: column;
     }
 
     .home-head {
         max-width: 100%;
+    }
+
+    .hero-wrapper {
+        position: absolute;
+        top: -40px;
+        right: -2rem;
+        margin-top: 0;
+        padding-top: 0;
+        width: 180px;
+        opacity: 1;
+        z-index: 0;
+    }
+
+    .hero-image {
+        max-width: 100%;
+        transform: perspective(1200px) rotate(6deg);
+    }
+
+    .hero-circular-text {
+        display: none;
+    }
+
+    p,
+    .home-head p,
+    .home-tail p,
+    .note-content p {
+        font-size: 15px;
+        line-height: 1.9em;
     }
 
     .work-row,


### PR DESCRIPTION
Fixes mobile layout issues on the hero section:

- Noise overlay now spans full viewport width instead of right half only
- Hero image positioned in top right corner on mobile with parallax scrolling
- Circular text spinner hidden on mobile due to size constraints
- Adjusted body paragraph text to 15px with 1.9em line-height for better mobile readability

All changes in the 860px media query breakpoint.