### PR TITLE
fix: blog post cover layout

### DIFF
--- a/pages/_note.html
+++ b/pages/_note.html
@@ -13,12 +13,13 @@
         <article class="note">
             <a class="back-link" href="../">← All Notes</a>
 
-            <header class="note-header">
-                <h1 class="note-title">{{ title }}</h1>
-                <p class="note-date">Penned on {{ date }}.</p>
-            </header>
-
-            {{{ coverImageHTML }}}
+            <div class="note-hero">
+                <header class="note-header">
+                    <h1 class="note-title">{{ title }}</h1>
+                    <p class="note-date">Penned on {{ date }}.</p>
+                </header>
+                {{{ coverImageHTML }}}
+            </div>
 
             <div class="note-content">{{{ content }}}</div>
         </article>

--- a/styles/main.css
+++ b/styles/main.css
@@ -22,6 +22,7 @@ html {
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
 }
 
 body {
@@ -495,7 +496,8 @@ a {
     padding-bottom: 4rem;
     margin: 0 auto;
     max-width: 100vw;
-    overflow-x: hidden;
+    overflow: visible;
+    position: relative;
 }
 
 .note > * {
@@ -507,16 +509,30 @@ a {
     padding: 40px 0 60px;
 }
 
+.note-hero {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 48px;
+    min-height: 180px;
+}
+
 .note-header {
     display: flex;
     flex-direction: column;
-    margin-bottom: 48px;
+    flex: 1;
+    min-width: 0;
 }
 
 .note-cover {
-    width: 100%;
-    border-radius: 8px;
-    margin-bottom: 48px;
+    width: 320px;
+    max-width: 40%;
+    border-radius: 0;
+    transform: rotate(3deg);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+    position: absolute;
+    right: -40px;
+    top: -30px;
+    z-index: 1;
 }
 
 .note-title {
@@ -783,5 +799,16 @@ sup {
 
     .note-header {
         margin-top: 0;
+    }
+
+    .note-hero {
+        min-height: auto;
+    }
+
+    .note-cover {
+        width: 200px;
+        max-width: 45%;
+        right: -20px;
+        top: -20px;
     }
 }


### PR DESCRIPTION
Featured image now positioned top-right, angled at 3°, bleeding from the top edge of the page. Hero section refactored to flex layout with absolutely positioned cover image. Removed border-radius for sharp corners and added overflow-x hidden on html to prevent horizontal scroll from image bleed.

**Changes:**
- Restructure note template with .note-hero wrapper
- Update .note-cover to position absolute relative to article
- Remove border-radius, adjust positioning for full-bleed effect

🤖 Generated with Claude Code