### PR TITLE
Add breadcrumb nav and homepage nav links

### DIFF
--- a/pages/_note.html
+++ b/pages/_note.html
@@ -10,8 +10,13 @@
         <link rel="stylesheet" href="../../styles/main.css" />
     </head>
     <body>
+        <nav class="breadcrumb container">
+            <a href="/">~</a>
+            <span class="breadcrumb-slash">/</span>
+            <a href="/notes/">NOTES</a>
+        </nav>
+
         <article class="note">
-            <a class="back-link" href="../">← All Notes</a>
 
             <div class="note-hero">
                 <header class="note-header">

--- a/pages/_notes.html
+++ b/pages/_notes.html
@@ -4,14 +4,22 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Notes — Siddharth</title>
-        <meta name="description" content="Siddharth's notes, essays & musings" />
+        <meta
+            name="description"
+            content="Siddharth's notes, essays & musings"
+        />
 
         <link rel="icon" type="image/png" href="../favicon.png" />
         <link rel="stylesheet" href="../styles/main.css" />
     </head>
     <body>
+        <nav class="breadcrumb container">
+            <a href="/">~</a>
+            <span class="breadcrumb-slash">/</span>
+            <span class="breadcrumb-active">NOTES</span>
+        </nav>
+
         <div class="notes-page container">
-            <a class="back-link" href="../">← Home</a>
             <h1>Siddharth's</h1>
             <p class="subtitle script">notes, essays & musings</p>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -24,7 +24,7 @@ description: Software Designer, Engineer and Generalist.
             <p>Startups are hard, let me know if I can help (^_^.)</p>
             <nav class="home-nav">
                 <a href="/notes/">⤷ notes</a>
-                <a href="/photos/">⤷ photos</a>
+                <!-- <a href="/photos/">⤷ photos</a> -->
             </nav>
         </div>
         <div class="hero-wrapper">

--- a/pages/index.html
+++ b/pages/index.html
@@ -11,44 +11,23 @@ description: Software Designer, Engineer and Generalist.
             <p class="script">@clearlysid</p>
             <p>Software Designer, Engineer and Generalist.</p>
             <p>
-                These days I build
-                <a href="https://helmer.app" target="_blank">Helmer</a> — a
-                bespoke video app, while helping a few friends with their own
-                startups.
+                I'm often found in "plan mode", clicking photos, trying new
+                recipes, taking long walks and befriending cats.
             </p>
             <p>
-                You'll often find me on long walks, reading memoirs, writing,
-                cooking new recipes or befriending cats.
+                These days I build
+                <a href="https://helmer.app" target="_blank">Helmer</a> — where
+                we hope to explore and accelerate creativity through interface
+                design.
             </p>
-            <p>Welcome to my internet corner ~ ᕕ(ᐛ)ᕗ</p>
-            <a class="read-essays-btn" href="/notes">Read Essays</a>
-            <p class="scroll-hint script">or scroll to explore my work ~</p>
+
+            <p>Startups are hard, let me know if I can help (^_^.)</p>
+            <nav class="home-nav">
+                <a href="/notes/">⤷ notes</a>
+                <a href="/photos/">⤷ photos</a>
+            </nav>
         </div>
         <div class="hero-wrapper">
-            <div class="hero-circular-text">
-                <svg viewBox="0 0 100 100" overflow="visible">
-                    <path
-                        id="circle-path"
-                        d="M 0 50 A 1 1 0 1 0 100 50 A 1 1 0 1 0 0 50"
-                        fill="transparent"
-                    />
-                    <text>
-                        <textPath
-                            href="#circle-path"
-                            startOffset="0"
-                            dominant-baseline="hanging"
-                            style="
-                                fill: #999;
-                                font-size: 14px;
-                                font-weight: 600;
-                                letter-spacing: 1.5px;
-                            "
-                        >
-                            SIDDHARTH ✨ @CLEARLYSID ✨
-                        </textPath>
-                    </text>
-                </svg>
-            </div>
             <div class="hero-image">
                 <img src="./img/hero.png" alt="Siddharth" />
             </div>

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -161,7 +161,7 @@ async function generateHTML() {
       await Bun.write(fullPath, html);
     }
 
-    // Generate notes listing page
+    // Generate all notes page
     notesMeta.sort((a, b) => (b.date > a.date ? 1 : -1));
 
     const listHTML = notesMeta
@@ -170,8 +170,8 @@ async function generateHTML() {
       })
       .join("\n");
 
-    if (templates["notes-listing"]) {
-      const listingHTML = render(templates["notes-listing"], {
+    if (templates["notes"]) {
+      const listingHTML = render(templates["notes"], {
         content: listHTML,
         ...baseData,
       });

--- a/styles/main.css
+++ b/styles/main.css
@@ -84,6 +84,44 @@ a {
     padding: 0 2rem;
 }
 
+/* ===== BREADCRUMB NAV ===== */
+.breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-top: 28px;
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+}
+
+.breadcrumb a,
+.breadcrumb-active {
+    padding: 5px 12px;
+    border-radius: 20px;
+    border: none;
+    transition: background-color 0.2s;
+}
+
+.breadcrumb a {
+    color: #999;
+}
+
+.breadcrumb a:hover {
+    background-color: rgba(0, 0, 0, 0.06);
+    color: #222;
+}
+
+.breadcrumb-active {
+    color: #222;
+    background-color: rgba(0, 0, 0, 0.06);
+}
+
+.breadcrumb-slash {
+    color: #bbb;
+}
+
 /* ===== HOMEPAGE ===== */
 
 .home-hero {
@@ -94,7 +132,7 @@ a {
 }
 
 .home-head {
-    max-width: 420px;
+    max-width: 440px;
     flex-shrink: 0;
 }
 
@@ -125,43 +163,41 @@ a {
     margin-bottom: 12px;
 }
 
-.home-head a:not(.read-essays-btn) {
+.home-head a:not(.home-nav a) {
     color: rgb(32, 84, 229);
-    border-bottom: none;
+    border-bottom: 1px solid transparent;
 }
 
-.home-head a:not(.read-essays-btn):hover {
-    border-bottom: 1px solid currentColor;
+.home-head a:not(.home-nav a):hover {
+    border-bottom-color: currentColor;
 }
 
-.read-essays-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    background: #222;
-    color: #fff;
-    padding: 0 20px;
-    height: 42px;
-    border-radius: 8px;
-    font-size: 16px;
-    font-weight: 500;
-    letter-spacing: -0.3px;
-    border: none;
-    cursor: pointer;
+.home-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
     margin-top: 24px;
     margin-bottom: 36px;
-    transition: opacity 0.2s;
 }
 
-.read-essays-btn:hover {
-    opacity: 0.85;
+.home-nav a {
+    font-size: 14px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #222;
+    border: none;
+    padding: 6px 10px;
+    margin-left: -10px;
+    border-radius: 2px;
+    background-color: transparent;
+    transition: background-color 0.2s;
+    white-space: nowrap;
+    width: fit-content;
 }
 
-.home-head .scroll-hint {
-    font-size: 36px;
-    letter-spacing: -0.5px;
-    line-height: 0.8;
+.home-nav a:hover {
+    background-color: rgba(0, 0, 0, 0.06);
 }
 
 /* Hero image */
@@ -185,27 +221,6 @@ a {
     max-width: 366px;
     height: auto;
     display: block;
-}
-
-.hero-circular-text {
-    position: absolute;
-    top: -45px;
-    left: 0px;
-    width: 60px;
-    height: 60px;
-    z-index: 0;
-    animation: spin 20s linear infinite;
-}
-
-.hero-circular-text svg {
-    width: 100%;
-    height: 100%;
-}
-
-@keyframes spin {
-    to {
-        transform: rotate(360deg);
-    }
 }
 
 /* Work section */
@@ -429,7 +444,11 @@ a {
     color: rgb(83, 83, 83);
 }
 
-/* ===== NOTES LISTING PAGE ===== */
+/* ===== NOTES LISTING PAGE ===== sa */
+
+.notes-page h1 {
+    padding-top: 60px;
+}
 
 .back-link {
     display: inline-flex;
@@ -507,6 +526,10 @@ a {
 
 .note .back-link {
     padding: 40px 0 60px;
+}
+
+.note .note-hero {
+    padding-top: 60px;
 }
 
 .note-hero {
@@ -738,10 +761,6 @@ sup {
     .hero-image {
         max-width: 100%;
         transform: perspective(1200px) rotate(6deg);
-    }
-
-    .hero-circular-text {
-        display: none;
     }
 
     p,


### PR DESCRIPTION
## Summary
- Add breadcrumb navigation (`~ / NOTES`) on note detail and notes listing pages, replacing old back-links
- Replace "Read Essays" button on homepage with `⤷ NOTES` / `⤷ PHOTOS` nav links with pill hover effect
- Remove circular SVG text, scroll hint, and related dead CSS
- Rename `_notes-listing.html` → `_notes.html` and update build script reference
- Update homepage copy and bump `.home-head` max-width

## Test plan
- [ ] Verify breadcrumb nav appears on notes listing and note detail pages
- [ ] Verify homepage shows ⤷ links with hover effect
- [ ] Verify no layout shift on hover
- [ ] Check responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)